### PR TITLE
Add `epquery.edit` to list of packages in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,9 @@ setup(name='epquery',
       license='BSD',
       platforms=['Windows', 'Linux'],
       packages=[
-          'epquery'],
+          'epquery',
+          'epquery.edit'
+      ],
       include_package_data=True,
       install_requires=[
           'numpy',


### PR DESCRIPTION
Subpackages should be listed explicitly otherwise they won't be installed (https://docs.python.org/2/distutils/examples.html#pure-python-distribution-by-package).